### PR TITLE
fixup for node["network"]["interfaces"]["eth0"]

### DIFF
--- a/files/default/plugins/vagrant-net.rb
+++ b/files/default/plugins/vagrant-net.rb
@@ -2,7 +2,7 @@
 
 # If the vagrant user exists we're running on Vagrant.  Not checking virtualization provider as Vagrant 1.1+ supports multiple.
 
-provide "ipaddress"
+provides "ipaddress", "network"
 require_plugin "#{os}::network"
 require_plugin "passwd"
 
@@ -14,6 +14,11 @@ if etc["passwd"].any? { |k,v| k == "vagrant"}
         ipaddress ip
       end
     end
+    Chef::Log.info("vagrant-ohai-plugin - replacing eth0")
+    network["interfaces"].delete("eth0")
+    eth1 = network["interfaces"].delete("eth1")
+    network["interfaces"]["eth0"] = eth1
+    network network
   else
     Chef::Log.debug("vagrant-ohai-plugin - eth1 not detected")
   end


### PR DESCRIPTION
`node["ipaddress"]` was fixed, while `node["network"]["interfaces"]["eth0"]` was still available.
So if you have any lookup for all available node node interfaces you would end up all nodes having the same NAT 10.0.2.15 address.

This fix replaces the remaining parts of eth0 in node["network"]